### PR TITLE
fixes center alignment of text in stickers when used in reflex grid

### DIFF
--- a/less/modules/stickers.less
+++ b/less/modules/stickers.less
@@ -62,6 +62,8 @@
 // Sticker elements
 .sticker__content {
     text-align: center;
+    text-align-last: center;
+    -moz-text-align-last: center;
     padding-top: .25em;
     display: table-cell;
     vertical-align: middle;


### PR DESCRIPTION
Small fix to make text aligned in firefox and ie>9 when stickers are used inside a reflex grid column