### PR TITLE
Off screen js

### DIFF
--- a/js/src/modules/accordion.js
+++ b/js/src/modules/accordion.js
@@ -21,9 +21,7 @@ module.exports = function($) {
         var $section = accordionBlock.element('section').block('accordion__section');
         var sectionBlock = $section.data('p.block');
 
-        // Our returned programmtic API.
-        // This allows us to do things beyond the scope of the module and let it
-        // play nicely with other modules, elements, etc
+        // Our returned programmtic API
         var api = {
             init: function() {
                 initAccordion();

--- a/js/src/modules/off-screen-menu.js
+++ b/js/src/modules/off-screen-menu.js
@@ -3,9 +3,12 @@
 module.exports = function($) {
     /**
      * Off screen menu component.
-     * Sets up event listeners on title click to open/close the off screen menu
+     * Sets up JavaScript enhahcement for browsers that don't support the CSS only method:
      *
-     * @param  jQuery node $accordion
+     * 1) Android stock browser (all versions)
+     * 2) iOS safari < 5
+     *
+     * @param  jQuery node $offScreen
      *
      * @return object
      */
@@ -16,30 +19,22 @@ module.exports = function($) {
         var $offScreenPageWrapper = $('.page-wrapper:first');
         var $offScreenHeader = $('.off-screen-header:first');
 
-        // Our returned programmtic API.
-        // This allows us to do things beyond the scope of the module and let it
-        // play nicely with other modules, elements, etc
+        // Our returned programmtic API
         var api = {
             init: function() {
                 initOffScreen();
             },
-            // Show off screen menu
-            show: function($elem) {
-                $offScreenMenu.addClass('off-screen--active');
-                $offScreenPageWrapper.addClass('off-screen--active');
-                $offScreenHeader.addClass('off-screen--active');
-            },
-            // Hide off screen menu
-            hide: function($elem) {
-                $offScreenMenu.removeClass('off-screen--active');
-                $offScreenPageWrapper.removeClass('off-screen--active');
-                $offScreenHeader.removeClass('off-screen--active');
+            requiresJsSupport: function() {
+                if (detectAndroidStockBrowser() || iOSversion() < 5) {
+                    return true;
+                }
             }
         }
 
         function initOffScreen() {
             // Bind click event listener
             $offScreenTrigger.on('click', function(e) {
+                $(this).toggleClass('off-screen--active');
                 $offScreenMenu.toggleClass('off-screen--active');
                 $offScreenPageWrapper.toggleClass('off-screen--active');
                 $offScreenHeader.toggleClass('off-screen--active');
@@ -48,8 +43,23 @@ module.exports = function($) {
             });
         }
 
-        // initialise off screen menu
-        api.init();
+        function iOSversion() {
+            if (/iP(hone|od touch|ad)/.test(navigator.platform)) {
+                var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+                return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+            }
+        }
+
+        function detectAndroidStockBrowser() {
+            var nua = navigator.userAgent;
+            var isAndroid = ((nua.indexOf('Mozilla/5.0') > -1 && nua.indexOf('Android ') > -1 && nua.indexOf('AppleWebKit') > -1) && !(nua.indexOf('Chrome') > -1));
+            return isAndroid;
+        }
+
+        // Initialise off screen menu js for browsers that don't support the CSS only method
+        if (api.requiresJsSupport()) {
+            api.init();
+        }
 
         return api;
     }

--- a/js/src/modules/off-screen-menu.js
+++ b/js/src/modules/off-screen-menu.js
@@ -2,99 +2,53 @@
 // This ensures each module is testable
 module.exports = function($) {
     /**
-     * Accordion component.
-     * Sets up event listeners on title click to open/close accordion sections
+     * Off screen menu component.
+     * Sets up event listeners on title click to open/close the off screen menu
      *
      * @param  jQuery node $accordion
      *
      * @return object
      */
-    return function($accordion) {
-        // Setup accordion block
-        var accordionBlock = $accordion.block('accordion').data('p.block');
-
-        // Setup Breakpoints if specified
-        var accordionBlockBreakpoints = accordionBlock.getDataAttr('data-accordion-responsive');
-        var accordionBlockBreakpointsArray = accordionBlockBreakpoints ? accordionBlockBreakpoints.split(",") : null;
-
-        // Setup section block
-        var $section = accordionBlock.element('section').block('accordion__section');
-        var sectionBlock = $section.data('p.block');
+    return function($offScreen) {
+        // Setup
+        var $offScreenTrigger = $offScreen;
+        var $offScreenMenu = $('.off-screen-menu:first');
+        var $offScreenPageWrapper = $('.page-wrapper:first');
+        var $offScreenHeader = $('.off-screen-header:first');
 
         // Our returned programmtic API.
         // This allows us to do things beyond the scope of the module and let it
         // play nicely with other modules, elements, etc
         var api = {
             init: function() {
-                initAccordion();
+                initOffScreen();
             },
-            // Show a section
+            // Show off screen menu
             show: function($elem) {
-                $elem.data('p.block').addModifier('active');
+                $offScreenMenu.addClass('off-screen--active');
+                $offScreenPageWrapper.addClass('off-screen--active');
+                $offScreenHeader.addClass('off-screen--active');
             },
-            // Hide a section
+            // Hide off screen menu
             hide: function($elem) {
-                $elem.data('p.block').removeModifier('active');
-            },
-            // Toggle a section
-            toggle: function($elem) {
-                $elem.data('p.block').toggleModifier('active');
-            },
-            // Show all sections
-            showAll: function() {
-                $section.each(function() {
-                    $(this).data('p.block').addModifier('active');
-                });
-            },
-            // Hide all sections
-            hideAll: function() {
-                $section.each(function() {
-                    $(this).data('p.block').removeModifier('active');
-                });
-            },
-            // Get value of pseudo element appended to body tag in pistachio.css
-            getViewportSize: function() {
-                return window.getComputedStyle(document.querySelector('body'), '::before').getPropertyValue('content').replace(/"/g, "").replace(/'/g, "");
+                $offScreenMenu.removeClass('off-screen--active');
+                $offScreenPageWrapper.removeClass('off-screen--active');
+                $offScreenHeader.removeClass('off-screen--active');
             }
         }
 
-        function initAccordion() {
-            $section.each(function() {
-                // Remove previous bindings
-                $(this).off('click', sectionBlock.elementSelector('title') + ':first');
-
-                // Default state of accordion based on provided breakpoints
-                if(accordionBlockBreakpointsArray) {
-                    if ($.inArray(api.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
-                        api.hide($(this));
-                    } else {
-                        api.show($(this));
-                    }
-                }
-            });
-
+        function initOffScreen() {
             // Bind click event listener
-            $section.on('click', sectionBlock.elementSelector('title') + ':first', function(e) {
-                if(accordionBlockBreakpointsArray) {
-                    // Set up responsive accordion if breakpoints are specified
-                    if ($.inArray(api.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
-                        e.preventDefault();
-                        api.toggle($(this).parent(accordionBlock.elementSelector('section')));
-                    }
-                } else {
-                    // if no breakpoints specified, set up accordion at all viewport sizes
-                    e.preventDefault();
-                    api.toggle($(this).parent(accordionBlock.elementSelector('section')));
-                }
+            $offScreenTrigger.on('click', function(e) {
+                $offScreenMenu.toggleClass('off-screen--active');
+                $offScreenPageWrapper.toggleClass('off-screen--active');
+                $offScreenHeader.toggleClass('off-screen--active');
+
+                e.preventDefault();
             });
         }
 
-        // reinit on window resize
-        $(window).resize(function() {
-            initAccordion();
-        });
-
-        // initialise accordion
+        // initialise off screen menu
         api.init();
 
         return api;

--- a/js/src/modules/off-screen-menu.js
+++ b/js/src/modules/off-screen-menu.js
@@ -1,0 +1,102 @@
+// Always export a function which takes jQuery as an argument
+// This ensures each module is testable
+module.exports = function($) {
+    /**
+     * Accordion component.
+     * Sets up event listeners on title click to open/close accordion sections
+     *
+     * @param  jQuery node $accordion
+     *
+     * @return object
+     */
+    return function($accordion) {
+        // Setup accordion block
+        var accordionBlock = $accordion.block('accordion').data('p.block');
+
+        // Setup Breakpoints if specified
+        var accordionBlockBreakpoints = accordionBlock.getDataAttr('data-accordion-responsive');
+        var accordionBlockBreakpointsArray = accordionBlockBreakpoints ? accordionBlockBreakpoints.split(",") : null;
+
+        // Setup section block
+        var $section = accordionBlock.element('section').block('accordion__section');
+        var sectionBlock = $section.data('p.block');
+
+        // Our returned programmtic API.
+        // This allows us to do things beyond the scope of the module and let it
+        // play nicely with other modules, elements, etc
+        var api = {
+            init: function() {
+                initAccordion();
+            },
+            // Show a section
+            show: function($elem) {
+                $elem.data('p.block').addModifier('active');
+            },
+            // Hide a section
+            hide: function($elem) {
+                $elem.data('p.block').removeModifier('active');
+            },
+            // Toggle a section
+            toggle: function($elem) {
+                $elem.data('p.block').toggleModifier('active');
+            },
+            // Show all sections
+            showAll: function() {
+                $section.each(function() {
+                    $(this).data('p.block').addModifier('active');
+                });
+            },
+            // Hide all sections
+            hideAll: function() {
+                $section.each(function() {
+                    $(this).data('p.block').removeModifier('active');
+                });
+            },
+            // Get value of pseudo element appended to body tag in pistachio.css
+            getViewportSize: function() {
+                return window.getComputedStyle(document.querySelector('body'), '::before').getPropertyValue('content').replace(/"/g, "").replace(/'/g, "");
+            }
+        }
+
+        function initAccordion() {
+            $section.each(function() {
+                // Remove previous bindings
+                $(this).off('click', sectionBlock.elementSelector('title') + ':first');
+
+                // Default state of accordion based on provided breakpoints
+                if(accordionBlockBreakpointsArray) {
+                    if ($.inArray(api.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
+                        api.hide($(this));
+                    } else {
+                        api.show($(this));
+                    }
+                }
+            });
+
+            // Bind click event listener
+            $section.on('click', sectionBlock.elementSelector('title') + ':first', function(e) {
+                if(accordionBlockBreakpointsArray) {
+                    // Set up responsive accordion if breakpoints are specified
+                    if ($.inArray(api.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
+                        e.preventDefault();
+                        api.toggle($(this).parent(accordionBlock.elementSelector('section')));
+                    }
+                } else {
+                    // if no breakpoints specified, set up accordion at all viewport sizes
+                    e.preventDefault();
+                    api.toggle($(this).parent(accordionBlock.elementSelector('section')));
+                }
+            });
+        }
+
+        // reinit on window resize
+        $(window).resize(function() {
+            initAccordion();
+        });
+
+        // initialise accordion
+        api.init();
+
+        return api;
+    }
+}

--- a/js/src/pistachio.js
+++ b/js/src/pistachio.js
@@ -18,6 +18,10 @@ var modules = {
     'accordion': moduleFactory('accordion', {
         module: require('./modules/accordion'),
         autoload: true
+    }),
+    'offScreen': moduleFactory('offScreen', {
+        module: require('./modules/off-screen-menu'),
+        autoload: true
     })
 };
 

--- a/less/modules/off-screen-menu.less
+++ b/less/modules/off-screen-menu.less
@@ -59,21 +59,6 @@
 // ---
 @media (max-width: @screen-xs-max) {
     //
-    // Set up an active state for use in the javascript enhancement
-    // ---
-    .off-screen--active {
-        .translate(@off-screen-menu-width, 0);
-
-        &.off-screen-menu {
-            .box-shadow(0 0 @off-screen-shadow-blur @colour-grey-lighter);
-        }
-
-        &.page-wrapper {
-            position: fixed;
-        }
-    }
-
-    //
     // When trigger is checked, transition menu and page to active state
     // ---
     .off-screen-trigger {
@@ -95,6 +80,37 @@
                 .translate(@off-screen-menu-width, 0);
                 position: fixed; // prevent scrolling of page when menu is active
             }
+        }
+    }
+
+    //
+    // Some browsers do not support combinations of checked and adjacent sibling selectors
+    // They also have a hard time with transforms so this is an alternative fallback which uses positioning instead
+    // It's not ideal and performs fairly slowly but at least it works in lieu of a better solution
+    //
+    // 1) Android stock browser (all versions)
+    // 2) iOS safari < 5
+    //
+    // This sets up an active state class for use in the javascript enhancement off-screen-menu.js
+    // ---
+    .off-screen--active {
+        &.off-screen-trigger-label {
+            .translate(@off-screen-menu-width, 0);
+        }
+
+        &.off-screen-menu {
+            .box-shadow(0 0 @off-screen-shadow-blur @colour-grey-lighter);
+            .translate(0, 0);
+            .position(fixed, 0, auto, 0, 0);
+        }
+
+        &.off-screen-header {
+            .translate(@off-screen-menu-width, 0);
+            .box-shadow(0 0 @off-screen-shadow-blur @colour-grey-lighter);
+        }
+
+        &.page-wrapper {
+            .translate(@off-screen-menu-width, 0);
         }
     }
 

--- a/less/modules/off-screen-menu.less
+++ b/less/modules/off-screen-menu.less
@@ -59,6 +59,21 @@
 // ---
 @media (max-width: @screen-xs-max) {
     //
+    // Set up an active state for use in the javascript enhancement
+    // ---
+    .off-screen--active {
+        .translate(@off-screen-menu-width, 0);
+
+        &.off-screen-menu {
+            .box-shadow(0 0 @off-screen-shadow-blur @colour-grey-lighter);
+        }
+
+        &.page-wrapper {
+            position: fixed;
+        }
+    }
+
+    //
     // When trigger is checked, transition menu and page to active state
     // ---
     .off-screen-trigger {

--- a/site/docs/views/examples/off-screen/off-screen-header.html
+++ b/site/docs/views/examples/off-screen/off-screen-header.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="grid grid--align-center grid--bleed">
             <div class="grid__col-auto off-screen-trigger-spacer">
-                <label for="off-screen-trigger" class="off-screen-trigger-label">
+                <label for="off-screen-trigger" class="off-screen-trigger-label" onclick>
                     <i class="fa fa-bars fa-2x"></i>
                     <span class="sr-only">toggle menu</span>
                 </label>

--- a/site/docs/views/layouts_off-screen-menu.hbs
+++ b/site/docs/views/layouts_off-screen-menu.hbs
@@ -4,7 +4,7 @@
     <div class="container">
         <div class="grid grid--align-center grid--bleed">
             <div class="grid__col-auto off-screen-trigger-spacer">
-                <label for="off-screen-trigger" class="off-screen-trigger-label">
+                <label for="off-screen-trigger" class="off-screen-trigger-label" onclick>
                     <i class="fa fa-bars fa-2x"></i>
                     <span class="sr-only">toggle menu</span>
                 </label>

--- a/site/docs/views/layouts_off-screen-menu.hbs
+++ b/site/docs/views/layouts_off-screen-menu.hbs
@@ -1,4 +1,4 @@
-<input type="checkbox" id="off-screen-trigger" class="off-screen-trigger">
+<input type="checkbox" id="off-screen-trigger" class="off-screen-trigger" data-p-module="offScreen">
 
 <div class="off-screen-header page-section page-section--xs">
     <div class="container">

--- a/site/docs/views/patterns_off-screen-menu.hbs
+++ b/site/docs/views/patterns_off-screen-menu.hbs
@@ -3,6 +3,12 @@
 
 <p class="cd-text">Any content placed inside the off screen menu will be moved off screen below 768px viewport width. At the same time, a label becomes visible with which the user can toggle the visibility of the off screen menu. It is intended to be used with <a href="navigation">navigation</a> elements to give you a mobile menu solution without writing additional markup.</p>
 
+<p class="cd-text">Some browsers do not support the css selectors used in this off-screen menu (<code>:checked</code> pseudo-class and <code>~</code> general sibling combinator) but this can be addressed by including pistachio.js. Affected browsers:</p>
+<ol class="cd-text">
+    <li>Android stock browser (all versions)</li>
+    <li>Safari on iOS below version 5 (iPhone 4 and below)</li>
+</ol>
+
 <h2 class="cd-text cd-title">menu trigger</h2>
 <p class="cd-text">A hidden checkbox input that is toggled by clicking the label. Must be a sibling of the menu content and page wrapper.</p>
 

--- a/site/docs/views/patterns_off-screen-menu.hbs
+++ b/site/docs/views/patterns_off-screen-menu.hbs
@@ -13,6 +13,8 @@
 <h2 class="cd-text cd-title">page header</h2>
 <p class="cd-text">This should be positioned at the top of the page directly after the opening <code>body</code> tag. This contains various elements such as the site logo and the off-screen menu trigger label.</p>
 
+<p class="cd-text">Please note the empty <code>onclick</code> attribute on the <code>&lt;label&gt;</code> is required to make it trigger the menu on ios < 6.0</p>
+
 {{#codeBlock}}
     {{{ getFile 'site/docs/views/examples/off-screen/off-screen-header.html' }}}
 {{/codeBlock}}


### PR DESCRIPTION
Some browsers do not support the css selectors used in this off-screen menu (:checked pseudo-class and ~ general sibling combinator) but this can be addressed by including pistachio.js. Affected browsers:

Android stock browser (all versions)
Safari on iOS below version 5 (iPhone 4 and below)