### PR TITLE
Smaller versions of the block nav and tabbed nav

### DIFF
--- a/less/includes/mixins.less
+++ b/less/includes/mixins.less
@@ -118,7 +118,6 @@
         @border: @colour-grey-lightest,
         @focus-border: @colour-grey-lightest
     ) {
-    padding: 0.5em 1em;
     border: 1px solid transparent;
     color: @text;
     background: @bg;

--- a/less/includes/variables.less
+++ b/less/includes/variables.less
@@ -191,3 +191,15 @@
 @off-screen-shadow-blur: 10px;
 @off-screen-logo-height: 50px;
 @off-screen-logo-width: 200px;
+
+//
+// Navigation
+// ---
+@nav-base:          4px;
+@nav-base-sm:       3px;
+
+@nav-spacing-xxs:   @nav-base-sm;       // 3px
+@nav-spacing-xs:    @nav-base;          // 4px
+@nav-spacing-sm:    @nav-base-sm * 2;   // 6px
+@nav-spacing-md:    @nav-base * 2;      // 8px
+@nav-spacing-lg:    @nav-base * 4;      // 16px

--- a/less/modules/navigation.less
+++ b/less/modules/navigation.less
@@ -16,7 +16,7 @@
     margin: 0;
 
     li {
-        .margins(0.5, 0, 0.5, 0);
+        margin: @nav-spacing-xs 0;
         vertical-align: middle;
     }
 }
@@ -24,7 +24,7 @@
 .nav__item {
     .nav-item-style();
     display: inline-block;
-    padding: 0.5em 1em;
+    padding: @nav-spacing-md @nav-spacing-lg;
 
 
     &:hover,
@@ -94,7 +94,7 @@
         margin: 0;
 
         .nav__item {
-            padding: 1em;
+            padding: @nav-spacing-lg;
         }
     }
 }
@@ -113,7 +113,6 @@
                 @colour-grey-lightest,
                 @colour-grey-lightest
             );
-            padding: 1em;
         }
 
         .nav__item--active {
@@ -130,11 +129,22 @@
 }
 
 //
+// Small block variant
+//
+.nav--block--sm {
+    li {
+        .nav__item {
+            padding: @nav-spacing-sm @nav-spacing-lg;
+        }
+    }
+}
+
+//
 // Tabbed nav variant
 // ---
 .nav--tabs {
     li {
-        .margins(0.5, 0, 0, 0.5);
+        margin: @nav-spacing-md 0 0 @nav-spacing-md;
 
         .nav__item {
             .nav-item-style(
@@ -145,7 +155,7 @@
                 @colour-grey-lightest,
                 @colour-grey-lightest
             );
-            padding: 0.5em 1em 1em;
+            padding: @nav-spacing-md @nav-spacing-lg @nav-spacing-lg;
             border-radius: @dimension-border-radius @dimension-border-radius 0 0;
         }
 
@@ -163,6 +173,19 @@
 }
 
 //
+// Small tabbed variant
+//
+.nav--tabs--sm {
+    li {
+        margin: @nav-spacing-xxs 0 0 @nav-spacing-xxs;
+
+        .nav__item {
+            padding: @nav-spacing-xxs @nav-spacing-md @nav-spacing-sm;
+        }
+    }
+}
+
+//
 // Tabbed nav with drop down menu
 // ---
 .nav-dropdown-wrapper {
@@ -173,7 +196,7 @@
     > li {
         display: block;
         float: left;
-        .margins(0.5, 0, 0, 0);
+        margin: @nav-spacing-md 0 0 0;
 
         .nav__item {
             padding: 0.5em 1em 1em;

--- a/less/modules/pagination.less
+++ b/less/modules/pagination.less
@@ -23,6 +23,7 @@
 .pagination__list__item {
     display: inline-block;
     .nav-item-style();
+    padding: 0.5em 1em;
     border-radius: @dimension-border-radius;
     text-decoration: none;
 

--- a/site/docs/views/examples/nav/nav-block-sm.html
+++ b/site/docs/views/examples/nav/nav-block-sm.html
@@ -1,0 +1,20 @@
+<nav>
+    <ul class="nav nav--block nav--block--sm">
+        <li>
+            <a class="nav__item nav__item--active" tabindex="-1" href="#">
+                our food
+            </a>
+        </li>
+        <li>
+            <a class="nav__item" href="#">
+                about us
+            </a>
+        </li>
+
+        <li>
+            <a class="nav__item" href="#">
+                our packaging
+            </a>
+        </li>
+    </ul>
+</nav>

--- a/site/docs/views/examples/nav/nav-tabs-sm.html
+++ b/site/docs/views/examples/nav/nav-tabs-sm.html
@@ -1,0 +1,21 @@
+<div class="page-section page-section--brand page-section--bleed">
+    <nav>
+        <ul class="nav nav--tabs nav--tabs--sm">
+            <li>
+                <a class="nav__item nav__item--active" tabindex="-1" href="#">
+                    about us
+                </a>
+            </li>
+            <li>
+                <a class="nav__item" href="#">
+                    our food
+                </a>
+            </li>
+            <li>
+                <a class="nav__item" href="#">
+                    our packaging
+                </a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/site/docs/views/patterns_navigation.hbs
+++ b/site/docs/views/patterns_navigation.hbs
@@ -5,11 +5,18 @@
     {{{ getFile 'site/docs/views/examples/nav/nav-block.html' }}}
 {{/codeBlock}}
 
+<h2 class="cd-text cd-title">small top level block nav</h2>
+<p class="cd-text">Use the <code>.nav--block--sm</code> modifier to generate a nav that uses less padding than the standard block nav.</p>
+
+{{{ getFile 'site/docs/views/examples/nav/nav-block-sm.html' }}}
+{{#codeBlock}}
+    {{{ getFile 'site/docs/views/examples/nav/nav-block-sm.html' }}}
+{{/codeBlock}}
+
 <h2 class="cd-text cd-title">inverse top level block nav</h2>
-<p class="cd-text">Use the <code>.nav--block</code> and <code>.nav--inverse</code> modifiers to generate a nav that uses blocks and works on dark backgrounds.</p>
+<p class="cd-text">Use the <code>.nav--block</code> or <code>.nav--block--sm</code> modifier with the <code>.nav--inverse</code> modifier to generate a nav that uses blocks and works on dark backgrounds.</p>
 
 {{{ getFile 'site/docs/views/examples/nav/nav-block-inverse.html' }}}
-
 {{#codeBlock}}
     {{{ getFile 'site/docs/views/examples/nav/nav-block-inverse.html' }}}
 {{/codeBlock}}
@@ -19,6 +26,13 @@
 {{{ getFile 'site/docs/views/examples/nav/nav-tabs.html' }}}
 {{#codeBlock}}
     {{{ getFile 'site/docs/views/examples/nav/nav-tabs.html' }}}
+{{/codeBlock}}
+
+<h2 class="cd-text cd-title">small tabbed nav</h2>
+<p class="cd-text">Use the <code>.nav--tabs--sm</code> modifier to generate a tabbed nav with less padding.</p>
+{{{ getFile 'site/docs/views/examples/nav/nav-tabs-sm.html' }}}
+{{#codeBlock}}
+    {{{ getFile 'site/docs/views/examples/nav/nav-tabs-sm.html' }}}
 {{/codeBlock}}
 
 <h2 class="cd-text cd-title">tabbed nav as dropdown menu</h2>


### PR DESCRIPTION
This adds 38px high versions of the block navigation and tabbed navigation bars. I'm using pixels for padding and margins instead of `em` because of rounding issues in browsers.