### PR TITLE
Make the default logo size smaller

### DIFF
--- a/less/includes/variables.less
+++ b/less/includes/variables.less
@@ -189,8 +189,8 @@
 @off-screen-menu-width: 240px;
 @off-screen-label-width: 2em;
 @off-screen-shadow-blur: 10px;
-@off-screen-logo-height: 50px;
-@off-screen-logo-width: 200px;
+@off-screen-logo-height: 42px;
+@off-screen-logo-width: 150px;
 
 //
 // Navigation


### PR DESCRIPTION
It looks better being slightly smaller. 42px chosen so it's the same size as a button. Opinions welcome.