### PR TITLE
Change the default nav colours to work with a grey background

### DIFF
--- a/less/includes/mixins.less
+++ b/less/includes/mixins.less
@@ -112,11 +112,11 @@
 // ---
 .nav-item-style(
         @text: @colour-brand,
-        @hover-text: @colour-white,
+        @hover-text: @colour-grey-dark,
         @bg: transparent,
-        @hover-bg: @colour-grey-light,
-        @border: @colour-grey-light,
-        @focus-border: @colour-grey-light
+        @hover-bg: @colour-grey-lighter,
+        @border: @colour-grey-lighter,
+        @focus-border: @colour-grey-lighter
     ) {
     border: 1px solid transparent;
     color: @text;

--- a/less/includes/mixins.less
+++ b/less/includes/mixins.less
@@ -111,12 +111,12 @@
 // Nav styles
 // ---
 .nav-item-style(
-        @text: @text-colour,
-        @hover-text: @text-colour,
+        @text: @colour-brand,
+        @hover-text: @colour-white,
         @bg: transparent,
-        @hover-bg: @colour-grey-lightest,
-        @border: @colour-grey-lightest,
-        @focus-border: @colour-grey-lightest
+        @hover-bg: @colour-grey-light,
+        @border: @colour-grey-light,
+        @focus-border: @colour-grey-light
     ) {
     border: 1px solid transparent;
     color: @text;


### PR DESCRIPTION
Makes the block nav look like this when on a grey background and still works on a white background.
<img width="347" alt="messages image 4186266838" src="https://cloud.githubusercontent.com/assets/5333300/11531367/4292c9ba-98f4-11e5-8753-4b96e7d7c5ff.png">
