### PR TITLE
Give default page sections a white background

### DIFF
--- a/less/modules/page-sections.less
+++ b/less/modules/page-sections.less
@@ -8,6 +8,7 @@
 
 .page-section {
     padding: 3em 0;
+    background-color: @colour-white;
 }
 
 .page-section--bleed {


### PR DESCRIPTION
graze.com has a grey background and this is the easiest way to make the navigation background white