### PR TITLE
Override the alternate page section colours

### DIFF
--- a/less/modules/off-screen-menu.less
+++ b/less/modules/off-screen-menu.less
@@ -169,6 +169,11 @@
             color: @text-colour;
         }
 
+        .page-section--alternate {
+            background-color: transparent;
+            color: @text-colour;
+        }
+
         .container {
             padding: 0;
         }


### PR DESCRIPTION
When a `page-section--alternate` is inside an off-screen-menu, this addition overrides the colours so the off screen menu remains white. 