### PR TITLE
Fix deployment of tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
     script: gulp publish --for-real
     on:
       tags: true
-      condition: "$TRAVIS_TAG = $(grep version package.json | awk '{ print $2 }' | sed 's/[\",]//g')"
+      condition: "$TRAVIS_TAG = $(grep version package.json | awk '{ print \"v\" $2 }' | sed 's/[\",]//g')"
 
 cache:
   directories:


### PR DESCRIPTION
Our tag convention is 'v5.0.0', but the version in package.json doesn't have a 'v' so we need to append it before comparing.