### PR TITLE
remove the js that forces you to copy the entirety of a code sample

### DIFF
--- a/js/docs/docs.js
+++ b/js/docs/docs.js
@@ -1,28 +1,7 @@
 (function(document) {
-    var $code = document.querySelectorAll('.hljs');
     var $h2 = document.querySelectorAll('h2.cd-title');
     var $pageNav = document.querySelector('.cd-page-nav');
     var i;
-
-    for (var i = 0; i < $code.length; i ++) {
-        $code[i].contentEditable = true;
-
-        $code[i].addEventListener('mouseup', function(e) {
-            document.execCommand('selectAll', false, null);
-
-            try {
-                document.execCommand('copy');
-
-                e.target.className += ' copied';
-
-                setTimeout(function() {
-                    e.target.className = e.target.className.replace(' copied', '');
-                }, 2000);
-            } catch(e) {
-                // No fail safe
-            }
-        });
-    }
 
     if ($pageNav && $h2.length > 1) {
         $pageNav.className += ' cd-page-nav--show';

--- a/less/docs.less
+++ b/less/docs.less
@@ -83,28 +83,6 @@ code {
     background: @colour-grey-lightest;
     position: relative;
 
-    &:after {
-        content: 'copy';
-        position: absolute;
-        right: 0;
-        bottom: 0;
-        background: fade(black, 60%);
-        color: white;
-        border-radius: 2px;
-        padding: .2em .4em;
-        opacity: 0;
-        cursor: pointer;
-    }
-
-    &:hover:after {
-        opacity: .5;
-    }
-
-    &.copied:after {
-        content: 'copied!';
-        opacity: 1;
-    }
-
     code {
         background: none;
     }


### PR DESCRIPTION
Currently when you click on a code sample in the pattern library, it automatically selects it all and places it in your clipboard. Often this is not desirable if you just want a class name or some smaller part of the code sample.

This PR removes that functionality.