### PR TITLE
Support any number of progress bar steps.

### DIFF
--- a/less/includes/mixins.less
+++ b/less/includes/mixins.less
@@ -483,6 +483,27 @@
 }
 
 //
+// Quantity selectors
+// ---
+.at-least(@quantity, @countTarget, @rules, @selectTarget: ~'') {
+    @lastChildQuantity: @quantity + 1;
+
+    // apply styles to the element we are counting when no 'select target' is given
+    @{countTarget}:nth-last-child(n + @{lastChildQuantity}) when (@selectTarget = ~'') {
+        @rules();
+    }
+
+    @{countTarget}:nth-last-child(n + @{lastChildQuantity}) ~ @{countTarget} when (@selectTarget = ~'') {
+        @rules();
+    }
+
+    // if a 'select target' is given apply the given styles to that element rather than the counted element
+    @{countTarget}:nth-last-child(n + @{lastChildQuantity}) ~ @{selectTarget} when not (@selectTarget = ~'') {
+        @rules();
+    }
+}
+
+//
 // Off-screen menu
 // ---
 .off-screen-menu-transition() {

--- a/less/modules/progress.less
+++ b/less/modules/progress.less
@@ -26,3 +26,43 @@
     background-color: @colour-brand;
     border-radius: 5px;
 }
+
+.progress__bar__step {
+    text-align: center;
+    margin-right: @dimension-padding-base;
+    margin-left: @dimension-padding-base;
+}
+
+.at-least(1, ~'.progress__bar__step', {
+    display: none;
+}, ~'.progress__bar__step-count');
+
+@media (max-width: @screen-xs-min) {
+    .at-least(3, ~'.progress__bar__step', {
+        display: none;
+    });
+
+    .at-least(3, ~'.progress__bar__step', {
+        display: block;
+    }, ~'.progress__bar__step-count');
+}
+
+@media (max-width: @screen-sm-min) {
+    .at-least(5, ~'.progress__bar__step', {
+        display: none;
+    });
+
+    .at-least(5, ~'.progress__bar__step', {
+        display: block;
+    }, ~'.progress__bar__step-count');
+}
+
+@media (max-width: @screen-lg-min) {
+    .at-least(7, ~'.progress__bar__step', {
+        display: none;
+    });
+
+    .at-least(7, ~'.progress__bar__step', {
+        display: block;
+    }, ~'.progress__bar__step-count');
+}

--- a/less/modules/progress.less
+++ b/less/modules/progress.less
@@ -27,6 +27,17 @@
     border-radius: 5px;
 }
 
+.progress__bar__steps {
+    // make browsers that don't support flexbox or text-align-last justify the step descriptions
+    &:after {
+        content: "";
+        display: inline-block;
+        width: 100%;
+        height: 0;
+        visibility: hidden;
+    }
+}
+
 .progress__bar__step {
     text-align: center;
     margin-right: @dimension-padding-base;

--- a/less/modules/progress.less
+++ b/less/modules/progress.less
@@ -33,6 +33,10 @@
     margin-left: @dimension-padding-base;
 }
 
+.progress__bar__step-count {
+    text-align: center;
+}
+
 .at-least(1, ~'.progress__bar__step', {
     display: none;
 }, ~'.progress__bar__step-count');

--- a/site/docs/views/examples/progress/progress-discrete-five-steps.html
+++ b/site/docs/views/examples/progress/progress-discrete-five-steps.html
@@ -1,0 +1,13 @@
+<div class="progress text-center">
+    <div class="progress__bar">
+        <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="40%" style="width: 40%;"></div>
+    </div>
+    <div class="grid grid--bleed grid--justify-space-between">
+        <p class="grid__col-auto progress__bar__step">Step 1</p>
+        <p class="grid__col-auto progress__bar__step">Step 2</p>
+        <p class="grid__col-auto progress__bar__step">Step 3</p>
+        <p class="grid__col-auto progress__bar__step">Step 4</p>
+        <p class="grid__col-auto progress__bar__step">Step 5</p>
+        <p class="grid__col-12 progress__bar__step-count">Step 1 of 5</p>
+    </div>
+</div>

--- a/site/docs/views/examples/progress/progress-discrete-five-steps.html
+++ b/site/docs/views/examples/progress/progress-discrete-five-steps.html
@@ -2,7 +2,7 @@
     <div class="progress__bar">
         <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="40%" style="width: 40%;"></div>
     </div>
-    <div class="grid grid--bleed grid--justify-space-between">
+    <div class="progress__bar__steps grid grid--bleed grid--justify-space-between">
         <p class="grid__col-auto progress__bar__step">Step 1</p>
         <p class="grid__col-auto progress__bar__step">Step 2</p>
         <p class="grid__col-auto progress__bar__step">Step 3</p>

--- a/site/docs/views/examples/progress/progress-discrete-three-steps.html
+++ b/site/docs/views/examples/progress/progress-discrete-three-steps.html
@@ -1,0 +1,10 @@
+<div class="progress text-center">
+    <div class="progress__bar">
+        <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="33%" style="width: 33%;"></div>
+    </div>
+    <div class="grid grid--bleed grid--justify-space-between">
+        <p class="grid__col-auto progress__bar__step">Step 1</p>
+        <p class="grid__col-auto progress__bar__step">Step 2</p>
+        <p class="grid__col-auto progress__bar__step">Step 3</p>
+    </div>
+</div>

--- a/site/docs/views/examples/progress/progress-discrete-three-steps.html
+++ b/site/docs/views/examples/progress/progress-discrete-three-steps.html
@@ -2,7 +2,7 @@
     <div class="progress__bar">
         <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="33%" style="width: 33%;"></div>
     </div>
-    <div class="grid grid--bleed grid--justify-space-between">
+    <div class="progress__bar__steps grid grid--bleed grid--justify-space-between">
         <p class="grid__col-auto progress__bar__step">Step 1</p>
         <p class="grid__col-auto progress__bar__step">Step 2</p>
         <p class="grid__col-auto progress__bar__step">Step 3</p>

--- a/site/docs/views/examples/progress/progress-step-count.html
+++ b/site/docs/views/examples/progress/progress-step-count.html
@@ -2,13 +2,7 @@
     <div class="progress__bar">
         <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="33%" style="width: 33%;"></div>
     </div>
-    <div class="col-xxs-4">
-        <p>Step 1</p>
-    </div>
-    <div class="col-xxs-4">
-        <p>Step 2</p>
-    </div>
-    <div class="col-xxs-4">
-        <p>Step 3</p>
+    <div class="grid grid--bleed grid--justify-space-between">
+        <p class="grid__col-12 progress__bar__step-count">Step 1 of 3</p>
     </div>
 </div>

--- a/site/docs/views/examples/progress/progress-step-count.html
+++ b/site/docs/views/examples/progress/progress-step-count.html
@@ -2,7 +2,7 @@
     <div class="progress__bar">
         <div class="progress__bar__fill" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="33%" style="width: 33%;"></div>
     </div>
-    <div class="grid grid--bleed grid--justify-space-between">
+    <div class="progress__bar__steps grid grid--bleed grid--justify-space-between">
         <p class="grid__col-12 progress__bar__step-count">Step 1 of 3</p>
     </div>
 </div>

--- a/site/docs/views/patterns_mixins.hbs
+++ b/site/docs/views/patterns_mixins.hbs
@@ -43,3 +43,41 @@ position: absolute;
 left: auto;
 right: auto;
 </pre>
+
+
+<h2 class="cd-text cd-title">at least</h2>
+<p class="cd-text">A quantity selector which applies styles based on the number of child elements.</p>
+
+<h3 class="cd-text cd-title">Syntax</h3>
+<code>.at-least(@quantity, @countTarget, @rules, @selectTarget: ~'');</code>
+
+<h3 class="cd-text cd-title">Example 1</h3>
+<p class="cd-text">Hide <code>.progress__bar__step</code> when there are three or more.</p>
+<code>
+.at-least(3, ~'.progress__bar__step', {
+    display: none;
+});
+</code>
+
+<p>Result:</p>
+<pre>
+.progress__bar__step:nth-last-child(n + 4),
+.progress__bar__step:nth-last-child(n + 4) ~ .progress__bar__step {
+    display: none;
+}
+</pre>
+
+<h3 class="cd-text cd-title">Example 2</h3>
+<p class="cd-text">When there are three or more <code>.progress__bar__step</code>, show the sibling <code>.progress__bar__step-count</code>.</p>
+<code>
+.at-least(3, ~'.progress__bar__step', {
+    display: block;
+}, ~'.progress__bar__step-count');
+</code>
+
+<p>Result:</p>
+<pre>
+.progress__bar__step:nth-last-child(n + 4) ~ .progress__bar__step-count} {
+    display: block;
+}
+</pre>

--- a/site/docs/views/patterns_progress.hbs
+++ b/site/docs/views/patterns_progress.hbs
@@ -1,9 +1,31 @@
 <h1 class="cd-text cd-title">progress indicator</h1>
 <p class="cd-text">Indicates progress along a set of steps.</p>
 
-{{{ getFile 'site/docs/views/examples/progress.html' }}}
+<h3 class="cd-text cd-title">three discrete steps with no step count</h3>
+
+<p class="cd-text">Up to three discrete progress steps are displayed at all times.</p>
+
+{{{ getFile 'site/docs/views/examples/progress/progress-discrete-three-steps.html' }}}
 {{#codeBlock}}
-    {{{ getFile 'site/docs/views/examples/progress.html' }}}
+    {{{ getFile 'site/docs/views/examples/progress/progress-discrete-three-steps.html' }}}
+{{/codeBlock}}
+
+<h3 class="cd-text cd-title">step count fall-back to support more than three discrete steps</h3>
+
+<p class="cd-text">Any number of discrete steps greater than three are hidden and replaced with a step count at pre-set breakpoints. This only accounts for the number of steps and does not consider the length of each label.</p>
+
+{{{ getFile 'site/docs/views/examples/progress/progress-discrete-five-steps.html' }}}
+{{#codeBlock}}
+    {{{ getFile 'site/docs/views/examples/progress/progress-discrete-five-steps.html' }}}
+{{/codeBlock}}
+
+<h3 class="cd-text cd-title">step count only with no discrete steps</h3>
+
+<p class="cd-text">By providing no discrete steps the step count will always be displayed at each breakpoint.</p>
+
+{{{ getFile 'site/docs/views/examples/progress/progress-step-count.html' }}}
+{{#codeBlock}}
+    {{{ getFile 'site/docs/views/examples/progress/progress-step-count.html' }}}
 {{/codeBlock}}
 
 <h2 class="cd-text cd-title">update progress on page load</h2>

--- a/site/docs/views/patterns_progress.hbs
+++ b/site/docs/views/patterns_progress.hbs
@@ -29,7 +29,7 @@
 {{/codeBlock}}
 
 <h2 class="cd-text cd-title">update progress on page load</h2>
-<p class="cd-text">To change the progress indicator between pages set the <code>width</code> of the <code>.progress__bar__fill</code> element to your desired percentage. You should also update the <code>aria-valuenow</code> attribute for improved accessiblity.</p>
+<p class="cd-text">To change the progress indicator between pages set the <code>width</code> of the <code>.progress__bar__fill</code> element to your desired percentage. You should also update the <code>aria-valuenow</code> attribute for improved accessiblity. If you're using the <code>.progress__bar__step-count</code> element then you should update the step number there too.</p>
 
 <h2 class="cd-text cd-title">update progress via JavaScript</h2>
 <p class="cd-text">Changing the width of the <code>.progress__bar__fill</code> element via JavaScript will trigger an animation on the <code>.progress__bar__fill</code> element. You should also update the <code>aria-valuenow</code> attribute at the same time for improved accessiblity.</p>


### PR DESCRIPTION
## Changes

### Benefits

1. The number of progress steps are no longer beholden to the grid (i.e. divisible into a 12 column grid).
2. Any number of steps are supported, falling back to a step count when there are too many steps for the viewport width to accommodate. This works on the quantity of steps rather than the length of their label.

### Disadvantages

1. Browsers that do not support flexbox are unable to equally space progress steps. How important is this, would a JavaScript enhancement be desirable or unnecessary?

### Implementation

Adds an `at least` mixin to style elements according to their quantity. In this case if there are a large number of progress steps we hide their label and show a step count. We also show the step count if no discrete steps are added. (see documentation examples)

## Docs Demo

See `http://localhost:4000/patterns/progress` documentation for a full overview.

![screen shot 2016-02-10 at 15 38 04](https://cloud.githubusercontent.com/assets/10405691/12951872/51bee0f0-d00c-11e5-8ddf-78c36b00f046.png)

## Device Support

Devices which support flexbox are optimal (mountain lion safari 6.1).
![mountain lion safari 6 1](https://cloud.githubusercontent.com/assets/10405691/12951937/9741dc0e-d00c-11e5-93ec-1248b2376dff.png)


Devices which support flexbox are optimal (windows phone 8).
![windows phone 8](https://cloud.githubusercontent.com/assets/10405691/12952196/8308c418-d00d-11e5-97c3-7c5baf4a39dd.png)

Devices which do not are unable to align progress steps (snow leopard safari 4).
![snow leopard safari 4](https://cloud.githubusercontent.com/assets/10405691/12951959/aeb5e092-d00c-11e5-98d7-cd68d719d37b.png)

Devices which do not are unable to align progress steps (IOS safari 5).
![ios 5 two options](https://cloud.githubusercontent.com/assets/10405691/12952171/6d7583ac-d00d-11e5-83f9-07b9e863ebd2.png)


IE9 and above appears to work well:
![win 7 ie9](https://cloud.githubusercontent.com/assets/10405691/12951971/bc11085c-d00c-11e5-9571-d4d7b86c4cca.png)

Example on iPhone 5s with three options (note, in the end I made three display at all times at this resolution, a similar landscape/portrait responsive demonstration could be achieved with four steps):
![5s 3 options](https://cloud.githubusercontent.com/assets/10405691/12952000/dc75a968-d00c-11e5-9974-00e7d5d022c1.png)

![5s 3 options landscape](https://cloud.githubusercontent.com/assets/10405691/12952019/e96c8f92-d00c-11e5-9dc1-ad09e3c80348.png)


## .gif Demo

Three steps, no fallback to step count until xxs (smaller resolution that iPhone 4):
![three](https://cloud.githubusercontent.com/assets/10405691/12951776/d19fd00a-d00b-11e5-8787-bc25adec4992.gif)

Five steps, falls back to step count:
![five](https://cloud.githubusercontent.com/assets/10405691/12951791/f0abf21c-d00b-11e5-813b-1d7067157493.gif)

Seven steps, falls back to step count sooner:
![seven](https://cloud.githubusercontent.com/assets/10405691/12951796/fb88feaa-d00b-11e5-8a4d-ae404170e8fc.gif)