### PR TITLE
Ribbons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For versioned releases of modules modify the url like so: `https://pistachio-cdn
  - [Pagination](https://pistachio-cdn.graze.com/dev/css/pagination.css)
  - [Panels](https://pistachio-cdn.graze.com/dev/css/panels.css)
  - [Progress](https://pistachio-cdn.graze.com/dev/css/progress.css)
+ - [Ribbons](https://pistachio-cdn.graze.com/dev/css/ribbons.css)
  - [Stickers](https://pistachio-cdn.graze.com/dev/css/stickers.css)
  - [Tables](https://pistachio-cdn.graze.com/dev/css/tables.css)
 
@@ -86,7 +87,7 @@ To view the style guide locally:
 ~$ npm start
 ```
 
-Docs should now be visible on ```http://localhost:4000/```. 
+Docs should now be visible on ```http://localhost:4000/```.
 
 Make sure to regularly run `npm update` to keep your dependencies up to date.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,8 +32,9 @@ var lessFileList = [
     './less/modules/pagination.less',
     './less/modules/panels.less',
     './less/modules/progress.less',
-    './less/modules/tables.less',
+    './less/modules/ribbons.less',
     './less/modules/stickers.less',
+    './less/modules/tables.less',
     './less/modules/off-screen-menu.less',
 
     // Docs

--- a/less/modules/ribbon.less
+++ b/less/modules/ribbon.less
@@ -1,0 +1,67 @@
+@ribbon-overlap: 0.3em;
+
+.ribbon__content {
+    background: @colour-error;
+    color: white;
+    padding: 2em/4;
+    text-align: center;
+    .box-shadow(0 @ribbon-overlap / 4 0 fade(black, 30%));
+}
+
+.ribbon {
+    position: absolute;
+    z-index: 1;
+    top: -@ribbon-overlap;
+    .square(7em);
+    overflow: hidden;
+    &:before,
+    &:after {
+        content: '';
+        position: absolute;
+        .square(@ribbon-overlap);
+        background: darken(@colour-error, 20%);
+        z-index: -1;
+    }
+    .ribbon__content {
+        position: absolute;
+        width: 200%;
+        top: 50%;
+        margin-top: -2em;
+    }
+}
+
+.ribbon--left {
+    left: -@ribbon-overlap;
+    &:before {
+        top: -1px;
+        right: 0;
+    }
+    &:after {
+        left: -1px;
+        bottom: 0;
+        right: -1px;
+    }
+    .ribbon__content {
+        .rotate(-45deg);
+        left: -50%;
+        margin-left: -2em/2;
+    }
+}
+
+.ribbon--right {
+    right: -@ribbon-overlap;
+    &:before {
+        bottom: auto;
+        top: -1px;
+        left: 0;
+    }
+    &:after {
+        bottom: 0;
+        right: -1px;
+    }
+    .ribbon__content {
+        .rotate(45deg);
+        right: -50%;
+        margin-right: -2em/2;
+    }
+}

--- a/less/modules/ribbons.less
+++ b/less/modules/ribbons.less
@@ -1,13 +1,15 @@
+// Includes
+@import '../includes/variables';
+@import '../includes/mixins';
+
+//
+// Ribbons
+// ===
+
+// Ribbon variables
 @ribbon-overlap: 0.3em;
 
-.ribbon__content {
-    background: @colour-error;
-    color: white;
-    padding: 2em/4;
-    text-align: center;
-    .box-shadow(0 @ribbon-overlap / 4 0 fade(black, 30%));
-}
-
+// Base ribbon (mandates a position modifier)
 .ribbon {
     position: absolute;
     z-index: 1;
@@ -30,6 +32,7 @@
     }
 }
 
+// Mandatory position modifiers
 .ribbon--left {
     left: -@ribbon-overlap;
     &:before {
@@ -64,4 +67,13 @@
         right: -50%;
         margin-right: -2em/2;
     }
+}
+
+// Ribbon content
+.ribbon__content {
+    background: @colour-error;
+    color: white;
+    padding: 2em/4;
+    text-align: center;
+    .box-shadow(0 @ribbon-overlap / 4 0 fade(black, 30%));
 }

--- a/less/pistachio.less
+++ b/less/pistachio.less
@@ -20,4 +20,5 @@
 @import 'modules/progress';
 @import 'modules/accordion';
 @import 'modules/stickers';
+@import 'modules/ribbon';
 @import 'modules/off-screen-menu';

--- a/less/pistachio.less
+++ b/less/pistachio.less
@@ -20,5 +20,5 @@
 @import 'modules/progress';
 @import 'modules/accordion';
 @import 'modules/stickers';
-@import 'modules/ribbon';
+@import 'modules/ribbons';
 @import 'modules/off-screen-menu';

--- a/site/docs/views/examples/ribbons/ribbon-left.html
+++ b/site/docs/views/examples/ribbons/ribbon-left.html
@@ -1,0 +1,3 @@
+<div class="ribbon ribbon--left">
+    <div class="ribbon__content">ribbon left</div>
+</div>

--- a/site/docs/views/examples/ribbons/ribbon-right.html
+++ b/site/docs/views/examples/ribbons/ribbon-right.html
@@ -1,0 +1,3 @@
+<div class="ribbon ribbon--right">
+    <div class="ribbon__content">ribbon right</div>
+</div>

--- a/site/docs/views/patterns_ribbons.hbs
+++ b/site/docs/views/patterns_ribbons.hbs
@@ -1,0 +1,48 @@
+<h1 class="cd-text cd-title">ribbon</h1>
+<p class="cd-text">A good use of ribbons is to indicate discounted products. A left or right modifier is a requirement for a working ribbon.</p>
+
+<h4 class="cd-text cd-title">ribbon left</h4>
+<div class="row">
+    <div class="col-xs-5">
+        <a class="panel panel--shadow" href="javascript:void(0);">
+            {{{ getFile 'site/docs/views/examples/ribbons/ribbon-left.html' }}}
+            <img src="http://lorempixel.com/400/200/food/2" class="img-responsive panel__header-img">
+            <div class="panel__body">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Et, repellat.
+                </p>
+            </div>
+            <div class="panel__footer">
+                £2.99
+            </div>
+        </a>
+    </div>
+    <div class="col-xs-7">
+        {{#codeBlock}}
+            {{{ getFile 'site/docs/views/examples/ribbons/ribbon-left.html' }}}
+        {{/codeBlock}}
+    </div>
+</div>
+
+<h4 class="cd-text cd-title">ribbon right</h4>
+<div class="row">
+    <div class="col-xs-5">
+        <a class="panel panel--shadow" href="javascript:void(0);">
+            {{{ getFile 'site/docs/views/examples/ribbons/ribbon-right.html' }}}
+            <img src="http://lorempixel.com/400/200/food/3" class="img-responsive panel__header-img">
+            <div class="panel__body">
+                <p>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                </p>
+            </div>
+            <div class="panel__footer">
+                £3.99
+            </div>
+        </a>
+    </div>
+    <div class="col-xs-7">
+        {{#codeBlock}}
+            {{{ getFile 'site/docs/views/examples/ribbons/ribbon-right.html' }}}
+        {{/codeBlock}}
+    </div>
+</div>


### PR DESCRIPTION
Add ribbons for use on product discounts, including a required left/right modifier. The requirement ensures less css because no resets are needed.

Android 4.1
![screen shot 2016-02-11 at 17 31 43](https://cloud.githubusercontent.com/assets/10405691/12984477/d5da780c-d0e5-11e5-969d-788a2940b45d.png)

IE9:
![screen shot 2016-02-11 at 17 32 49](https://cloud.githubusercontent.com/assets/10405691/12984576/4bd3f07e-d0e6-11e5-83a7-60e275bea134.png)

Sexy close-up:
![screen shot 2016-02-11 at 17 36 21](https://cloud.githubusercontent.com/assets/10405691/12984523/08cfc3de-d0e6-11e5-94d5-3ad040d24d6b.png)
