### PR TITLE
Refactor common viewport / resize behaviour

### DIFF
--- a/js/src/modules/accordion.js
+++ b/js/src/modules/accordion.js
@@ -12,6 +12,8 @@ module.exports = function($) {
 
     // Dependencies
     var agentDetection = require('../utils/agent-detection')($);
+    var viewportDetection = require('../utils/viewport-detection')($);
+    var respond = require('../utils/respond');
 
     return function($accordion) {
         // Setup accordion block
@@ -98,22 +100,19 @@ module.exports = function($) {
                 } else {
                     api.show($elem);
                 }
-            },
-            // Get value of pseudo element appended to body tag in pistachio.css
-            getViewportSize: function() {
-                return window.getComputedStyle(document.querySelector('body'), '::before').getPropertyValue('content').replace(/"/g, "").replace(/'/g, "");
             }
         }
 
         // initialise accordion
         function initAccordion() {
+
             $section.each(function() {
                 // Remove previous bindings
                 $(this).off('click keydown', sectionBlock.elementSelector('title') + ':first');
 
                 // Default state of accordion based on provided breakpoints
                 if(accordionBlockBreakpointsArray) {
-                    if ($.inArray(api.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
+                    if ($.inArray(viewportDetection.getViewportSize(), accordionBlockBreakpointsArray) > -1) {
                         api.enable($(this));
                         api.hide($(this));
                     } else {
@@ -141,15 +140,9 @@ module.exports = function($) {
 
         // Check if we have a responsive accordion
         if (accordionBlockBreakpointsArray) {
-            // Reinitialise accordion on window resize for all but Safari iOS < 6
-            // Because Safari iOS < 6 throws erroneous resize events all the time
-            if (! agentDetection.iOSversion() || agentDetection.iOSversion() > 6) {
-                var resizeEventId;
-                $(window).resize(function() {
-                    clearTimeout(resizeEventId);
-                    resizeEventId = setTimeout(api.init, 100);
-                });
-            }
+            // Setup respond object to react to breakpoints
+            var responder = respond($, viewportDetection, agentDetection);
+            responder.respondOnBreakpoints(api.init, accordionBlockBreakpointsArray);
         }
 
         // Make api available

--- a/js/src/modules/drop-down.js
+++ b/js/src/modules/drop-down.js
@@ -11,6 +11,8 @@ module.exports = function($) {
 
     // Dependencies
     var agentDetection = require('../utils/agent-detection')($);
+    var viewportDetection = require('../utils/viewport-detection')($);
+    var respond = require('../utils/respond');
 
     return function($dropDown) {
         var dropDownBlock = $dropDown.block('nav').data('p.block');
@@ -61,16 +63,13 @@ module.exports = function($) {
                     dropDownTabsBlock.element('item').attr('aria-expanded','false').blur();
                     $(this).removeClass('nav__dropdown--active');
                 });
-            },
-            getViewportSize: function() {
-                return window.getComputedStyle(document.querySelector('body'), '::before').getPropertyValue('content').replace(/"/g, "").replace(/'/g, "");
             }
         }
 
         function init() {
             // When drop-down has optional off screen menu data attribute, handle differently
             if(dropDownOffScreenArray) {
-                if ($.inArray(api.getViewportSize(), dropDownOffScreenArray) > -1) {
+                if ($.inArray(viewportDetection.getViewportSize(), dropDownOffScreenArray) > -1) {
                     api.resetAllBindings();
                     api.initOffScreen();
                 } else {
@@ -111,20 +110,9 @@ module.exports = function($) {
         }
 
         if (dropDownOffScreenArray) {
-            // Reinitialise dropdown on window resize for all but Safari iOS < 6
-            // Because Safari iOS < 6 throws erroneous resize events all the time
-            if (! agentDetection.iOSversion() || agentDetection.iOSversion() > 6) {
-                var oldBreakpoint = api.getViewportSize();
-
-                $(window).resize(function() {
-                    var newBreakpoint = api.getViewportSize();
-                    // only reinitialise if breakpoints have changed
-                    if (newBreakpoint !== oldBreakpoint) {
-                        api.init();
-                    }
-                    oldBreakpoint = newBreakpoint;
-                });
-            }
+            // Setup respond object to react to breakpoints
+            var responder = respond($, viewportDetection, agentDetection);
+            responder.respondOnBreakpoints(api.init, dropDownOffScreenArray);
         }
 
         api.init();

--- a/js/src/utils/respond.js
+++ b/js/src/utils/respond.js
@@ -1,0 +1,35 @@
+/**
+ * Listens to the resize event and responds as required with a provided callback
+ * Optionally accepts target breakpoints and only calls the callback if the breakpoint switches between these and breakpoints not targeted
+ *
+ * @param  jQuery $
+ * @param  viewportDetection viewportDetection
+ *
+ * @return object
+ */
+module.exports = function($, viewportDetection, agentDetection) {
+
+    var oldBreakpoint = viewportDetection.getViewportSize();
+
+    var api = {
+        respondOnBreakpoints: function(callback, targetBreakpoints) {
+            // Because Safari iOS < 6 throws erroneous resize events all the time
+            if (! agentDetection.iOSversion() || agentDetection.iOSversion() > 6) {
+                $(window).resize(function() {
+                    var newBreakpoint = viewportDetection.getViewportSize(),
+                        newBreakpointTargeted = $.inArray(newBreakpoint, targetBreakpoints) !== -1,
+                        oldBreakpointTargeted = $.inArray(oldBreakpoint, targetBreakpoints) !== -1,
+                        targetBreakpointChange = (newBreakpointTargeted && ! oldBreakpointTargeted) || (! newBreakpointTargeted && oldBreakpointTargeted);
+
+                    if ((typeof targetBreakpoints === 'undefined' || targetBreakpointChange) && (newBreakpoint !== oldBreakpoint)) {
+                        callback();
+                    }
+
+                    oldBreakpoint = newBreakpoint;
+                });
+            }
+        }
+    }
+
+    return api;
+}

--- a/js/src/utils/viewport-detection.js
+++ b/js/src/utils/viewport-detection.js
@@ -1,0 +1,17 @@
+/**
+ * Returns the viewport size e.g. "sm", "md".
+ *
+ * @param  jQuery $
+ *
+ * @return object
+ */
+module.exports = function($) {
+    var api = {
+        getViewportSize: function() {
+            var bodyPseudoBeforeElement = window.getComputedStyle(document.querySelector('body'), '::before');
+            return bodyPseudoBeforeElement.getPropertyValue('content').replace(/"/g, "").replace(/'/g, "");
+        }
+    }
+
+    return api;
+}


### PR DESCRIPTION
Effects the dropdown and accordion. 

- Moves `getViewportSize` to a utils js file 'viewport-detection.js'
- Creates 'respond.js' which applies a callback on breakpoint changes. Either on any breakpoint change or when switching from one of a specified set of breakpoints to a non-specified breakpoint. E.g. providing breakpoints [xs, sm] would only trigger the callback when switching to or from a breakpoint greater than 'sm'.

Benefits:

- Drier code
- Executing js in a more targeted fashion, with less running at each breakpoint e.g. the off-screen-menu only re-initialises when going from viewports 'sm' to 'md' rather than at every breakpoint change (which also means resizing the browser with a menu tab open no longer closes the menu).