### PR TITLE
Use `npm version` to release new versions of the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,28 @@ script:
   - npm test
 
 deploy:
+  # Deploy resources on master branch pushes.
   - provider: script
     skip_cleanup: true
     script: gulp publish
     on:
       branch: master
+
+  # Deploy resources on a new release.
   - provider: script
     skip_cleanup: true
     script: gulp publish --for-real
     on:
       tags: true
-      condition: "$TRAVIS_TAG = $(grep version package.json | awk '{ print \"v\" $2 }' | sed 's/[\",]//g')"
+      condition: "$TRAVIS_TAG = $(grep -m 1 version package.json | awk '{ print \"v\" $2 }' | sed 's/[\",]//g')"
+
+  # Deploy the style guide on master branch pushes.
+  - provider: heroku
+    api_key:
+      secure: "SAoCtu3N0BEwjo1yiMkESANSckYGx9718PgusJLUu9Pe0N/yRG8cU3iTAFMHt5ow4lY1GJquJBoIotjgF4LFs6B3AwSuwGTHatcTLtXwc/xLxB7DBLOObitwVy66CZXiJ5qG1KBuHaLhW/bNOIoXdrFfGuLhPHpOAjJs44tAS9joCPkpAt4maMQOmkzdfDMSEnT7NZRBWAOMdQm6QEXt6sTFllIfIqpxemB/YTWjnHBUk0JmDCfs7rfD6CkDwXZqeJERvUyo5kV3GP/FuFUw/MJyw+AuOAf6Cj8MdsCt1mo5hHgq6vHRBzm3CYV6My9n8q9aOezvoiGW8h+TmmymdMrR9iiGR3XgJT2oLSYgSRPsj34Nbia/GTlptqfk+Bub/WDkhg9dx+auD9U6vX/wyP5yrbDI+L0LqWaF/KdkEE72lraXTtXEDkna6qAwOIqZmmmAWnaF8Ua+xkChu7lMhq1Za8lYyr4r+esV/MjgGwiNE+IS85dImYb2rB5SlIol7vwJY3P83WIma+j5NcYA3V2toCJAeJi/Bbib34q4PAr2MAq3ymSgwdnR9tYVsHEjbIsSov5Sc1Fr0SjAi6zAXk2Xj2m4CiU2XiMlD0mzPhj8xafpYpBC2xkM41ffqwjV4gSsNqq78qOwRB+ckTxfVU7A3UFSdA3SkJ7+Sazx/8I="
+    app: graze-pistachio
+    on:
+      branch: master
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -113,13 +113,9 @@ To compile the JavaScript:
 
 The projects documentation and style guide is deployed to Heroku on every push to the master branch and is visible at http://pistachio.graze.com/.
 
-Follow these simple steps to deploy a new version:
+Follow these simple steps to deploy a versioned release:
 
-1. Update `version` within `package.json`
-2. Commit the changes to a new branch ([with a good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html))
-3. Push the new branch (`git push`)
-4. [Open a pull request](https://github.com/graze/pistachio/pull/new/master) and get it merged
-5. Tag the change (`git tag v0.0.x` )
-6. Push the tag (`git push --tags`)
-7. Travis CI will publish the new version to CloudFront
-8. [Update the release notes on GitHub](https://github.com/graze/pistachio/releases)
+1. Run `npm version -m ":rocket: Release %s."` on the `master` branch with a [semver](http://semver.org/) as it's argument (e.g. `npm version -m ":rocket: Release %s." 1.0.0`)
+2. A new `release/` branch, and tag, will be published to GitHub, open a PR to merge the branch into `master`
+3. [The Travis CI build for the tag](https://travis-ci.org/graze/pistachio/builds) will publish the resources to s3 and trigger Heroku to deploy the style guide
+4. [Update the release notes on GitHub](https://github.com/graze/pistachio/releases), not forgetting the html snippets printed out in the build

--- a/build/post-version.sh
+++ b/build/post-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Ensure that failed commands halt the script.
+set -eo pipefail
+
+# Extract the version from `package.json`.
+VERSION=$(grep -m 1 version package.json | awk '{ print "v" $2 }' | sed 's/[\",]//g')
+
+# Rename the local branch now we know the version number.
+git branch -m release-$(git rev-parse --short HEAD^) release-$VERSION
+
+# Publish the branch and the tagged release.
+git push -u origin release-$VERSION
+git push origin --tags
+
+# Checkout the last branch we were on, hopefully `master`.
+git checkout -
+
+# Open the branch as a PR to merge it into master.
+if [ -x "$(which open)" ]; then open "https://github.com/graze/pistachio/pull/new/release-$VERSION"; fi

--- a/build/pre-version.sh
+++ b/build/pre-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Ensure that failed commands halt the script.
+set -eo pipefail
+
+# Assert that we're releasing from the master branch.
+[ "$(git rev-parse --abbrev-ref HEAD)" = 'master' ]
+
+# Make sure we're not releasing a version that already exists.
+git fetch --tags
+
+# Create a temporary local branch.
+git checkout -b release-$(git rev-parse --short HEAD)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "postinstall": "gulp build",
     "start": "node ./site/docs/app.js",
     "test": "gulp build && gulp dev:profile && npm run test:js",
-    "test:js": "node ./tests/js/jasmine.js"
+    "test:js": "node ./tests/js/jasmine.js",
+    "preversion": "./build/pre-version.sh",
+    "postversion": "./build/post-version.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Major changes:

* Use of `npm version` cli command for releasing new versions
* Move the Heroku deployment trigger for the `master` branch into Travis CI

The latter ensures that tests are passing before we deploy the style guide.