### PR TITLE
Update the Cache-Control header values

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,7 +196,7 @@ gulp.task('publish', ['build'], function() {
                 Bucket: 'graze.pistachio',
                 Key: file.path,
                 ContentType: mime.lookup(file.path),
-                CacheControl: ('for-real' in argv) ? 'public max-age=31104000' : 'no-cache',
+                CacheControl: ('for-real' in argv) ? 'public, max-age=31540000, stale-while-revalidate=2628000, stale-if-error=2628000' : 'public, max-age=86400, must-revalidate',
                 Body: file.contents
             };
 


### PR DESCRIPTION
Adds a missing comma, updated value to 365 days of caching, makes use of http://httpwg.org/specs/rfc5861.html. Cache the dev version too, but ensure clients check the resources are up to date.