### PR TITLE
Remove gulp build post install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ To view the style guide locally:
 
 ```bash
 ~$ npm install
+~$ gulp build
 ~$ npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "graze front end framework",
   "main": "index.js",
   "scripts": {
-    "postinstall": "gulp build",
     "start": "node ./site/docs/app.js",
     "test": "gulp build && gulp dev:profile && npm run test:js",
     "test:js": "node ./tests/js/jasmine.js",

--- a/site/README.md
+++ b/site/README.md
@@ -4,7 +4,7 @@ The public docs in the master branch make up the publicly available site here: [
 
 TL;DR
 ---
- - `npm install && npm start` to run style guide site
+ - `npm install && gulp build && npm start` to run style guide site
  - If a new page is not showing, restart the app!
 
 File Structure


### PR DESCRIPTION
We don't always want to run `gulp build` on postinstall, for example when including as a dependency within other projects to share variables.

I don't think this will effect deployment as `npm test`, which includes gulp build, is run at deployment (see travis.yml).