### PR TITLE
:rocket: Release 0.1.5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pistachio",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "graze front end framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Removes max-height limitation on accordions and instead uses display to hide/show.
- Improves colour documentation.
- Stops `gulp build` from running during npm's postinstall unless an environment variable `$BUILD_ASSETS` is set.