### PR TITLE
remove :target usage when js is available

### DIFF
--- a/less/modules/navigation.less
+++ b/less/modules/navigation.less
@@ -224,12 +224,23 @@
     border-top: none;
     .border-bottom-radius(@dimension-border-radius);
 
-    &:target,
     &--active {
         position: relative;
         visibility: visible;
         z-index: @z-index-top;
         .border-bottom-radius(0);
+    }
+}
+
+// when there's no js, make it work with :target
+.experience-core {
+    .tabbed-content__section {
+        &:target {
+            position: relative;
+            visibility: visible;
+            z-index: @z-index-top;
+            .border-bottom-radius(0);
+        }
     }
 }
 


### PR DESCRIPTION
@notlee this accounts for the fact that some browsers still respect the :target css even when the location had changed. I'm just avoiding the issue altogether by only applying that css when js is unavailable.