### PR TITLE
allows banners to display correctly on firefox mobile

### DIFF
--- a/less/modules/features.less
+++ b/less/modules/features.less
@@ -82,6 +82,7 @@
     }
 
     @media (max-width: @screen-md-min) {
+        display: block;
         min-height: 100px;
         background-size: 150%;
         background-position: top right;


### PR DESCRIPTION
Before this fix, on firefox below the mobile breakpoint the banner image was not visible. Now it is.