### PR TITLE
adds default box sizing to pistachio

### DIFF
--- a/less/common/normalise.less
+++ b/less/common/normalise.less
@@ -3,6 +3,19 @@
 // ---
 
 //
+// Reset the box-sizing
+// ---
+
+* {
+    .box-sizing(border-box);
+}
+
+*:before,
+*:after {
+    .box-sizing(border-box);
+}
+
+//
 // HTML5 display definitions
 // ---
 

--- a/less/common/scaffolding.less
+++ b/less/common/scaffolding.less
@@ -2,22 +2,6 @@
 // Scaffolding
 // ---
 
-//
-// Reset the box-sizing
-//
-// NB this is already handled in reflex-grid
-// If we ever remove reflex-grid as a dependency we'd need to reintroduce this here
-// ---
-
-// * {
-//     .box-sizing(border-box);
-// }
-
-// *:before,
-// *:after {
-//     .box-sizing(border-box);
-// }
-
 // html defaults
 html {
     font-size: @font-size-base;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "mime": "^1.3.4",
     "minimist": "^1.1.2",
     "moment": "^2.10.6",
-    "reflex-grid": "^1.0.9",
+    "reflex-grid": "^1.1.1",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
@notlee this updates reflex to the latest version, where box-sizing is only applied to the grid itself, not via use of a `*` wildcard so I've added that box-sizing to pistachio itself.

