### PR TITLE
improves health badge layout when they wrap

### DIFF
--- a/less/modules/health-badges.less
+++ b/less/modules/health-badges.less
@@ -11,7 +11,7 @@
 .health-badge {
     display: inline-block;
     vertical-align: middle;
-    .square(3.0em);
+    .square(3.5em);
     .graze-font();
     padding-top: 0.8em;
     font-size: 1.2em;

--- a/less/modules/health-badges.less
+++ b/less/modules/health-badges.less
@@ -11,7 +11,7 @@
 .health-badge {
     display: inline-block;
     vertical-align: middle;
-    .square(3.5em);
+    .square(3.0em);
     .graze-font();
     padding-top: 0.8em;
     font-size: 1.2em;
@@ -23,6 +23,11 @@
     background-repeat: no-repeat;
     background-size: contain;
     background-position: 100% center;
+    margin-right: -.75em;
+
+    &:last-of-type {
+        margin-right: 0;
+    }
 
     &:hover {
         color: @colour-white;
@@ -32,10 +37,6 @@
     &:focus {
         background-color: @colour-white;
         .box-shadow(0 0 0 2px @colour-brand);
-    }
-
-    & + & {
-        margin-left: -.75em;
     }
 }
 

--- a/site/docs/views/patterns_health-badges.hbs
+++ b/site/docs/views/patterns_health-badges.hbs
@@ -151,6 +151,24 @@
 <a href="#0" class="health-badge health-badge--protein">
     <span class="sr-only">A source of protein</span>
 </a>
+<a href="#0" class="health-badge health-badge--fibre-uk">
+    <span class="sr-only">high in fibre</span>
+</a>
+<a href="#0" class="health-badge health-badge--vitamins">
+    <span class="sr-only">A source of at least two vitamins and minerals</span>
+</a>
+<a href="#0" class="health-badge health-badge--protein">
+    <span class="sr-only">A source of protein</span>
+</a>
+<a href="#0" class="health-badge health-badge--fibre-uk">
+    <span class="sr-only">high in fibre</span>
+</a>
+<a href="#0" class="health-badge health-badge--vitamins">
+    <span class="sr-only">A source of at least two vitamins and minerals</span>
+</a>
+<a href="#0" class="health-badge health-badge--protein">
+    <span class="sr-only">A source of protein</span>
+</a>
 
 <h2 class="cd-text cd-title">Usage without links</h2>
 <p class="cd-text">Ideally health badges would be used as a navigation aid and on click would filter by health badge or direct users to a page that collects all products that contain that health badge. If this is not possible, use of a <code>div</code> element is appropriate.</p>

--- a/site/docs/views/patterns_health-badges.hbs
+++ b/site/docs/views/patterns_health-badges.hbs
@@ -151,24 +151,6 @@
 <a href="#0" class="health-badge health-badge--protein">
     <span class="sr-only">A source of protein</span>
 </a>
-<a href="#0" class="health-badge health-badge--fibre-uk">
-    <span class="sr-only">high in fibre</span>
-</a>
-<a href="#0" class="health-badge health-badge--vitamins">
-    <span class="sr-only">A source of at least two vitamins and minerals</span>
-</a>
-<a href="#0" class="health-badge health-badge--protein">
-    <span class="sr-only">A source of protein</span>
-</a>
-<a href="#0" class="health-badge health-badge--fibre-uk">
-    <span class="sr-only">high in fibre</span>
-</a>
-<a href="#0" class="health-badge health-badge--vitamins">
-    <span class="sr-only">A source of at least two vitamins and minerals</span>
-</a>
-<a href="#0" class="health-badge health-badge--protein">
-    <span class="sr-only">A source of protein</span>
-</a>
 
 <h2 class="cd-text cd-title">Usage without links</h2>
 <p class="cd-text">Ideally health badges would be used as a navigation aid and on click would filter by health badge or direct users to a page that collects all products that contain that health badge. If this is not possible, use of a <code>div</code> element is appropriate.</p>


### PR DESCRIPTION
@notlee this fixes the layout issues when health badges wrap

before:

![screen shot 2016-10-05 at 16 52 53](https://cloud.githubusercontent.com/assets/713293/19120976/bafbdbb0-8b1c-11e6-9187-411352a66950.png)

after:
![screen shot 2016-10-05 at 16 52 06](https://cloud.githubusercontent.com/assets/713293/19120975/baed5a18-8b1c-11e6-9db7-527cbcc93251.png)
