### PR TITLE
Do not wrap to one word per line with the screen reader only class.

### DIFF
--- a/less/common/utilities.less
+++ b/less/common/utilities.less
@@ -162,6 +162,7 @@
     overflow: hidden;
     clip: rect(0,0,0,0);
     border: 0;
+    white-space: nowrap; // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe#.ikie4atoo
 }
 
 // Use in conjunction with .sr-only to only display content when it's focused.


### PR DESCRIPTION
Do not wrap to one word per line with the screen reader only class, as this could force words to be read as if they have no space.
https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe#.ikie4atoo